### PR TITLE
0.63.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ colored = "2.1.0"
 serde = "1.0.201"
 serde_json = "1.0.117"
 structopt = { version = "0.3.26", default-features = false }
-sway-ast = "0.60.0"
-sway-error = "0.60.0"
-sway-parse = "0.60.0"
-sway-types = "0.60.0"
-sway-ast-stubs = { git = "https://github.com/ourovoros-io/sway-ast-stubs.git", rev = "7326c1e" }
+sway-ast = "0.63.1"
+sway-error = "0.63.1"
+sway-parse = "0.63.1"
+sway-types = "0.63.1"
+sway-ast-stubs = { git = "https://github.com/ourovoros-io/sway-ast-stubs.git", rev = "b4f0b56ca9a7d9500cb84849b32cc36e3744913f" }

--- a/src/detectors/arbitrary_asset_transfer.rs
+++ b/src/detectors/arbitrary_asset_transfer.rs
@@ -176,6 +176,6 @@ impl AstVisitor for ArbitraryAssetTransferVisitor {
 mod tests {
     #[test]
     fn test_arbitrary_asset_transfer() {
-        crate::tests::test_detector("arbitrary_asset_transfer", 10);
+        crate::tests::test_detector("arbitrary_asset_transfer", 8);
     }
 }

--- a/src/detectors/manipulatable_balance_usage.rs
+++ b/src/detectors/manipulatable_balance_usage.rs
@@ -77,7 +77,7 @@ impl AstVisitor for ManipulatableBalanceUsageVisitor {
         // Get the module state
         let module_state = self.module_states.get_mut(context.path).unwrap();
 
-        for field in &context.item_storage.fields.inner {
+        for field in &context.item_storage.entries.inner {
             if field.value.span().as_str().contains("balance") {
                 module_state.balances.insert(field.value.span(), field.value.name.span().as_str().to_string());
             }

--- a/src/detectors/unchecked_call_payload.rs
+++ b/src/detectors/unchecked_call_payload.rs
@@ -354,6 +354,6 @@ impl AstVisitor for UncheckedCallPayloadVisitor {
 mod tests {
     #[test]
     fn test_unchecked_call_payload() {
-        crate::tests::test_detector("unchecked_call_payload", 2);
+        crate::tests::test_detector("unchecked_call_payload", 1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,7 +172,7 @@ pub mod tests {
         let entries  = filter_entries(&project.report.borrow(), &options);
         project.report.borrow_mut().entries = entries.into_iter().collect();
 
-        assert_eq!(project.report.borrow().entries[0].1.len(), 31);
+        assert_eq!(project.report.borrow().entries[0].1.len(), 26);
 
         println!("{project}");
     }
@@ -194,7 +194,7 @@ pub mod tests {
         let entries  = filter_entries(&project.report.borrow(), &options);
         project.report.borrow_mut().entries = entries.into_iter().collect();
 
-        assert_eq!(project.report.borrow().entries[0].1.len(), 15);
+        assert_eq!(project.report.borrow().entries[0].1.len(), 16);
 
         println!("{project}");
     }
@@ -216,7 +216,7 @@ pub mod tests {
         let entries  = filter_entries(&project.report.borrow(), &options);
         project.report.borrow_mut().entries = entries.into_iter().collect();
 
-        assert_eq!(project.report.borrow().entries[0].1.len(), 31);
+        assert_eq!(project.report.borrow().entries[0].1.len(), 26);
 
         println!("{project}");
     }
@@ -260,7 +260,7 @@ pub mod tests {
         let entries  = filter_entries(&project.report.borrow(), &options);
         project.report.borrow_mut().entries = entries.into_iter().collect();
 
-        assert_eq!(project.report.borrow().entries[0].1.len(), 16);
+        assert_eq!(project.report.borrow().entries[0].1.len(), 10);
 
         println!("{project}");
     }
@@ -282,7 +282,7 @@ pub mod tests {
         let entries  = filter_entries(&project.report.borrow(), &options);
         project.report.borrow_mut().entries = entries;
 
-        assert_eq!(project.report.borrow().entries[0].1.len(), 31);
+        assert_eq!(project.report.borrow().entries[0].1.len(), 26);
 
         println!("{project}");
     }

--- a/src/project.rs
+++ b/src/project.rs
@@ -188,9 +188,9 @@ impl Project<'_> {
         let mut module_paths = modules.borrow().keys().cloned().collect::<Vec<_>>();
         module_paths.sort();
 
-        let core = AstScope::from_library(self, "core");
+        // let core = AstScope::from_library(self, "core");
         
-        let std = AstScope::from_library(self, "std");
+        // let std = AstScope::from_library(self, "std");
         
         for path in module_paths {
             println!("{}", path.to_string_lossy());

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -189,12 +189,12 @@ impl AstScope {
                     }
 
                     ItemKind::Storage(item_storage) => {
-                        for field in &item_storage.fields.inner {
+                        for field in &item_storage.entries.inner {
                             scope.borrow_mut().add_variable(
                                 project,
                                 AstVariableKind::Storage,
                                 &field.value.name,
-                                &field.value.ty,
+                                &field.value.field.as_ref().unwrap().ty,
                             );
                         }
                     }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -189,13 +189,15 @@ impl AstScope {
                     }
 
                     ItemKind::Storage(item_storage) => {
-                        for field in &item_storage.entries.inner {
-                            scope.borrow_mut().add_variable(
-                                project,
-                                AstVariableKind::Storage,
-                                &field.value.name,
-                                &field.value.field.as_ref().unwrap().ty,
-                            );
+                        for entry in &item_storage.entries.inner {
+                            if let Some(field) = entry.value.field.as_ref() {
+                                scope.borrow_mut().add_variable(
+                                    project,
+                                    AstVariableKind::Storage,
+                                    &entry.value.name,
+                                    &field.ty,
+                                );
+                            }
                         }
                     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1270,7 +1270,7 @@ pub fn collect_storage_fields(module: &Module) -> Vec<&StorageField> {
         ..
     }) = module.items.iter().find(|x| matches!(x.value, ItemKind::Storage(_))) else { return vec![] };
 
-    fold_punctuated(&storage.fields.inner).iter().map(|x| &x.value).collect()
+    fold_punctuated(&storage.entries.inner).iter().map(|x| x.value.field.as_ref().unwrap()).collect()
 }
 
 pub fn is_boolean_literal_or_negation(expr: &Expr) -> bool {
@@ -1541,7 +1541,7 @@ pub fn ty_to_string(ty: &Ty) -> String {
         Ty::StringArray { length, .. } => format!("str[{}]", length.inner.span().as_str()),
         Ty::Infer { .. } => "_".into(),
         Ty::Ptr { ptr_token, ty } => format!("{}[{}]", ptr_token.span().as_str(), ty_to_string(ty.inner.as_ref())),
-        Ty::Slice { slice_token, ty } => format!("{}[{}]", slice_token.span().as_str(), ty_to_string(ty.inner.as_ref())),
+        Ty::Slice { slice_token, ty } => format!("{}[{}]", slice_token.as_ref().unwrap().span().as_str(), ty_to_string(ty.inner.as_ref())),
         
         Ty::Ref { ampersand_token, mut_token, ty } => format!(
             "{}{} {}",

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -802,7 +802,7 @@ impl AstVisitor for AstVisitorRecursive<'_> {
     }
 
     fn visit_use(&mut self, context: &UseContext, scope: Rc<RefCell<AstScope>>, project: &mut Project) -> Result<(), Error> {
-        scope.borrow_mut().add_use(context.item_use);
+        // scope.borrow_mut().add_use(context.item_use);
         
         for visitor in self.visitors.iter_mut() {
             visitor.visit_use(context, scope.clone(), project)?;
@@ -828,13 +828,13 @@ impl AstVisitor for AstVisitorRecursive<'_> {
     }
 
     fn visit_struct(&mut self, context: &StructContext, scope: Rc<RefCell<AstScope>>, project: &mut Project) -> Result<(), Error> {
-        scope.borrow_mut().add_struct(project, context.item_struct);
+        // scope.borrow_mut().add_struct(project, context.item_struct);
 
         let scope = Rc::new(RefCell::new(AstScope::new(Some(scope.clone()))));
         
-        if let Some(generics) = context.item_struct.generics.as_ref() {
-            scope.borrow_mut().add_generic_params(project, generics, context.item_struct.where_clause_opt.as_ref());
-        }
+        // if let Some(generics) = context.item_struct.generics.as_ref() {
+        //     scope.borrow_mut().add_generic_params(project, generics, context.item_struct.where_clause_opt.as_ref());
+        // }
         
         for visitor in self.visitors.iter_mut() {
             visitor.visit_struct(context, scope.clone(), project)?;
@@ -899,13 +899,13 @@ impl AstVisitor for AstVisitorRecursive<'_> {
     }
 
     fn visit_enum(&mut self, context: &EnumContext, scope: Rc<RefCell<AstScope>>, project: &mut Project) -> Result<(), Error> {
-        scope.borrow_mut().add_enum(project, context.item_enum);
+        // scope.borrow_mut().add_enum(project, context.item_enum);
 
         let scope = Rc::new(RefCell::new(AstScope::new(Some(scope.clone()))));
         
-        if let Some(generics) = context.item_enum.generics.as_ref() {
-            scope.borrow_mut().add_generic_params(project, generics, context.item_enum.where_clause_opt.as_ref());
-        }
+        // if let Some(generics) = context.item_enum.generics.as_ref() {
+        //     scope.borrow_mut().add_generic_params(project, generics, context.item_enum.where_clause_opt.as_ref());
+        // }
         
         for visitor in self.visitors.iter_mut() {
             visitor.visit_enum(context, scope.clone(), project)?;
@@ -970,42 +970,42 @@ impl AstVisitor for AstVisitorRecursive<'_> {
     }
 
     fn visit_fn(&mut self, context: &FnContext, scope: Rc<RefCell<AstScope>>, project: &mut Project) -> Result<(), Error> {
-        scope.borrow_mut().add_fn_signature(project, &context.item_fn.fn_signature);
+        // scope.borrow_mut().add_fn_signature(project, &context.item_fn.fn_signature);
         
         let scope = Rc::new(RefCell::new(AstScope::new(Some(scope.clone()))));
         
-        if let Some(generics) = context.item_fn.fn_signature.generics.as_ref() {
-            scope.borrow_mut().add_generic_params(project, generics, context.item_fn.fn_signature.where_clause_opt.as_ref());
-        }
+        // if let Some(generics) = context.item_fn.fn_signature.generics.as_ref() {
+        //     scope.borrow_mut().add_generic_params(project, generics, context.item_fn.fn_signature.where_clause_opt.as_ref());
+        // }
 
         let args = match &context.item_fn.fn_signature.arguments.inner {
             FnArgs::Static(args) => Some(args),
 
             FnArgs::NonStatic { args_opt, .. } => {
-                scope.borrow_mut().add_variable(
-                    project,
-                    AstVariableKind::Parameter,
-                    &BaseIdent::new_no_span("self".into()),
-                    &context.item_impl.as_ref().unwrap().ty,
-                );
+                // scope.borrow_mut().add_variable(
+                //     project,
+                //     AstVariableKind::Parameter,
+                //     &BaseIdent::new_no_span("self".into()),
+                //     &context.item_impl.as_ref().unwrap().ty,
+                // );
 
                 args_opt.as_ref().map(|(_, args)| args)
             }
         };
 
-        if let Some(args) = args {
-            for arg in args {
-                crate::utils::map_pattern_and_ty(&arg.pattern, &arg.ty, &mut |pattern, ty| {
-                    match pattern {
-                        Pattern::Var { name, .. } => {
-                            scope.borrow_mut().add_variable(project, AstVariableKind::Parameter, name, ty);
-                        }
+        // if let Some(args) = args {
+        //     for arg in args {
+        //         crate::utils::map_pattern_and_ty(&arg.pattern, &arg.ty, &mut |pattern, ty| {
+        //             match pattern {
+        //                 Pattern::Var { name, .. } => {
+        //                     scope.borrow_mut().add_variable(project, AstVariableKind::Parameter, name, ty);
+        //                 }
 
-                        _ => {}
-                    }
-                });
-            }
-        }
+        //                 _ => {}
+        //             }
+        //         });
+        //     }
+        // }
 
         for visitor in self.visitors.iter_mut() {
             visitor.visit_fn(context, scope.clone(), project)?;
@@ -1130,21 +1130,21 @@ impl AstVisitor for AstVisitorRecursive<'_> {
     }
 
     fn visit_statement_let(&mut self, context: &StatementLetContext, scope: Rc<RefCell<AstScope>>, project: &mut Project) -> Result<(), Error> {
-        crate::utils::map_pattern_and_ty(
-            &context.statement_let.pattern,
-            &context.statement_let.ty_opt.as_ref()
-                .map(|(_, ty)| ty.clone())
-                .unwrap_or_else(|| scope.borrow().get_expr_ty(&context.statement_let.expr, project)),
-            &mut |pattern, ty| {
-                match pattern {
-                    Pattern::Var { name, .. } => {
-                        scope.borrow_mut().add_variable(project, AstVariableKind::Local, name, ty);
-                    }
+        // crate::utils::map_pattern_and_ty(
+        //     &context.statement_let.pattern,
+        //     &context.statement_let.ty_opt.as_ref()
+        //         .map(|(_, ty)| ty.clone())
+        //         .unwrap_or_else(|| scope.borrow().get_expr_ty(&context.statement_let.expr, project)),
+        //     &mut |pattern, ty| {
+        //         match pattern {
+        //             Pattern::Var { name, .. } => {
+        //                 scope.borrow_mut().add_variable(project, AstVariableKind::Local, name, ty);
+        //             }
 
-                    _ => {}
-                }
-            },
-        );
+        //             _ => {}
+        //         }
+        //     },
+        // );
 
         for visitor in self.visitors.iter_mut() {
             visitor.visit_statement_let(context, scope.clone(), project)?;
@@ -2608,19 +2608,19 @@ impl AstVisitor for AstVisitorRecursive<'_> {
                     // NOTE: `lhs` pattern can be handled by overriding `visit_if_expr`
                     //
 
-                    crate::utils::map_pattern_and_ty(
-                        lhs.as_ref(),
-                        &scope.borrow().get_expr_ty(rhs, project),
-                        &mut |pattern, ty| {
-                            match pattern {
-                                Pattern::Var { name, .. } => {
-                                    scope.borrow_mut().add_variable(project, AstVariableKind::Local, name, ty);
-                                }
+                    // crate::utils::map_pattern_and_ty(
+                    //     lhs.as_ref(),
+                    //     &scope.borrow().get_expr_ty(rhs, project),
+                    //     &mut |pattern, ty| {
+                    //         match pattern {
+                    //             Pattern::Var { name, .. } => {
+                    //                 scope.borrow_mut().add_variable(project, AstVariableKind::Local, name, ty);
+                    //             }
 
-                                _ => {}
-                            }
-                        },
-                    );
+                    //             _ => {}
+                    //         }
+                    //     },
+                    // );
 
                     let rhs_context = ExprContext {
                         path: context.path,
@@ -2957,13 +2957,13 @@ impl AstVisitor for AstVisitorRecursive<'_> {
     }
 
     fn visit_trait(&mut self, context: &TraitContext, scope: Rc<RefCell<AstScope>>, project: &mut Project) -> Result<(), Error> {
-        scope.borrow_mut().add_trait(project, context.item_trait);
+        // scope.borrow_mut().add_trait(project, context.item_trait);
         
         let scope = Rc::new(RefCell::new(AstScope::new(Some(scope.clone()))));
         
-        if let Some(generics) = context.item_trait.generics.as_ref() {
-            scope.borrow_mut().add_generic_params(project, generics, context.item_trait.where_clause_opt.as_ref());
-        }
+        // if let Some(generics) = context.item_trait.generics.as_ref() {
+        //     scope.borrow_mut().add_generic_params(project, generics, context.item_trait.where_clause_opt.as_ref());
+        // }
         
         for visitor in self.visitors.iter_mut() {
             visitor.visit_trait(context, scope.clone(), project)?;
@@ -2989,13 +2989,13 @@ impl AstVisitor for AstVisitorRecursive<'_> {
     }
 
     fn visit_impl(&mut self, context: &ImplContext, scope: Rc<RefCell<AstScope>>, project: &mut Project) -> Result<(), Error> {
-        scope.borrow_mut().add_impl(project, context.item_impl);
+        // scope.borrow_mut().add_impl(project, context.item_impl);
 
         let scope = Rc::new(RefCell::new(AstScope::new(Some(scope.clone()))));
         
-        if let Some(generics) = context.item_impl.generic_params_opt.as_ref() {
-            scope.borrow_mut().add_generic_params(project, generics, context.item_impl.where_clause_opt.as_ref());
-        }
+        // if let Some(generics) = context.item_impl.generic_params_opt.as_ref() {
+        //     scope.borrow_mut().add_generic_params(project, generics, context.item_impl.where_clause_opt.as_ref());
+        // }
         
         for visitor in self.visitors.iter_mut() {
             visitor.visit_impl(context, scope.clone(), project)?;
@@ -3072,7 +3072,7 @@ impl AstVisitor for AstVisitorRecursive<'_> {
     }
 
     fn visit_abi(&mut self, context: &AbiContext, scope: Rc<RefCell<AstScope>>, project: &mut Project) -> Result<(), Error> {
-        scope.borrow_mut().add_abi(project, context.item_abi);
+        // scope.borrow_mut().add_abi(project, context.item_abi);
 
         for visitor in self.visitors.iter_mut() {
             visitor.visit_abi(context, scope.clone(), project)?;
@@ -3102,12 +3102,12 @@ impl AstVisitor for AstVisitorRecursive<'_> {
             .map(|(_, ty)| ty.clone())
             .unwrap_or_else(|| scope.borrow().get_expr_ty(context.item_const.expr_opt.as_ref().unwrap(), project));
         
-        scope.borrow_mut().add_variable(
-            project,
-            AstVariableKind::Constant,
-            &context.item_const.name,
-            &ty,
-        );
+        // scope.borrow_mut().add_variable(
+        //     project,
+        //     AstVariableKind::Constant,
+        //     &context.item_const.name,
+        //     &ty,
+        // );
 
         for visitor in self.visitors.iter_mut() {
             visitor.visit_const(context, scope.clone(), project)?;
@@ -3190,12 +3190,12 @@ impl AstVisitor for AstVisitorRecursive<'_> {
     }
 
     fn visit_storage_field(&mut self, context: &StorageFieldContext, scope: Rc<RefCell<AstScope>>, project: &mut Project) -> Result<(), Error> {
-        scope.borrow_mut().add_variable(
-            project,
-            AstVariableKind::Storage,
-            &context.field.name,
-            &context.field.ty,
-        );
+        // scope.borrow_mut().add_variable(
+        //     project,
+        //     AstVariableKind::Storage,
+        //     &context.field.name,
+        //     &context.field.ty,
+        // );
 
         for visitor in self.visitors.iter_mut() {
             visitor.visit_storage_field(context, scope.clone(), project)?;
@@ -3276,12 +3276,12 @@ impl AstVisitor for AstVisitorRecursive<'_> {
     }
 
     fn visit_configurable_field(&mut self, context: &ConfigurableFieldContext, scope: Rc<RefCell<AstScope>>, project: &mut Project) -> Result<(), Error> {
-        scope.borrow_mut().add_variable(
-            project,
-            AstVariableKind::Configurable,
-            &context.field.name,
-            &context.field.ty,
-        );
+        // scope.borrow_mut().add_variable(
+        //     project,
+        //     AstVariableKind::Configurable,
+        //     &context.field.name,
+        //     &context.field.ty,
+        // );
 
         for visitor in self.visitors.iter_mut() {
             visitor.visit_configurable_field(context, scope.clone(), project)?;
@@ -3323,7 +3323,7 @@ impl AstVisitor for AstVisitorRecursive<'_> {
     }
 
     fn visit_type_alias(&mut self, context: &TypeAliasContext, scope: Rc<RefCell<AstScope>>, project: &mut Project) -> Result<(), Error> {
-        scope.borrow_mut().add_type_alias(project, context.item_type_alias);
+        // scope.borrow_mut().add_type_alias(project, context.item_type_alias);
 
         for visitor in self.visitors.iter_mut() {
             visitor.visit_type_alias(context, scope.clone(), project)?;

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -3159,7 +3159,7 @@ impl AstVisitor for AstVisitorRecursive<'_> {
             hook(context, scope.clone(), project)?;
         }
 
-        for field in &context.item_storage.fields.inner {
+        for field in &context.item_storage.entries.inner {
             let context = StorageFieldContext {
                 path: context.path,
                 module: context.module,
@@ -3167,7 +3167,7 @@ impl AstVisitor for AstVisitorRecursive<'_> {
                 storage_attributes: context.attributes,
                 item_storage: context.item_storage,
                 field_attributes: field.attribute_list.as_slice(),
-                field: &field.value,
+                field: &field.value.field.as_ref().unwrap(),
             };
 
             self.visit_storage_field(&context, scope.clone(), project)?;

--- a/test/arbitrary_asset_transfer/src/main.sw
+++ b/test/arbitrary_asset_transfer/src/main.sw
@@ -1,10 +1,11 @@
 contract;
-use std::constants::{BASE_ASSET_ID, ZERO_B256};
-use std::asset::{force_transfer_to_contract, transfer, transfer_to_address};
+use std::constants::{DEFAULT_SUB_ID, ZERO_B256};
+use std::asset::transfer;
 use std::low_level_call::{call_with_function_selector, CallParams};
 use std::bytes::Bytes;
 use std::context::msg_amount;
 use std::storage::storage_key::*;
+
 
 abi TestArbitraryAssetTransfer {
     #[storage(read, write)]
@@ -24,12 +25,12 @@ abi TestArbitraryAssetTransfer {
     fn arbitrary_transfer_protected(to: Identity, asset_id: AssetId, amount: u64);
 
     #[storage(read)]
-    fn arbitraty_transfer_to_sender();
+    fn arbitraty_transfer_to_sender(asset_id: AssetId);
     #[storage(read)]
-    fn arbitraty_transfer_to_sender_protected();
+    fn arbitraty_transfer_to_sender_protected(asset_id: AssetId);
 
-    fn transfer_to_msg_sender();
-    fn transfer_to_msg_sender_msg_value();
+    fn transfer_to_msg_sender(asset_id: AssetId);
+    fn transfer_to_msg_sender_msg_value(asset_id: AssetId);
 
     fn arbitrary_asset_transfer(to_ident: Identity, to_address: Address, to_contract: ContractId, asset_id: AssetId, amount: u64, target: ContractId,
         function_selector: Bytes,
@@ -43,7 +44,7 @@ abi TestArbitraryAssetTransfer {
         call_params: CallParams,
         single_value_type_arg: bool);
     #[storage(read)]
-    fn arbitrary_asset_transfer_from_sender();
+    fn arbitrary_asset_transfer_from_sender(asset_id: AssetId);
 }
 
 storage {
@@ -99,50 +100,35 @@ impl TestArbitraryAssetTransfer for Contract {
     }
 
      #[storage(read)]
-    fn arbitraty_transfer_to_sender() {
+    fn arbitraty_transfer_to_sender(asset_id: AssetId) {
         let sender = storage.sender.read().unwrap();
-        let sender = match sender {
-            Identity::Address(sender) => sender,
-            _ => { revert(0)}
-        };
         // Report entry should be created
         // L110: The `Contract::arbitraty_transfer_to_sender` function contains an arbitrary native asset transfer: `transfer_to_address(sender, BASE_ASSET_ID, 1)`
-        transfer_to_address(sender, BASE_ASSET_ID, 1);
+        transfer(sender, asset_id, 1);
     }
 
      #[storage(read)]
-    fn arbitraty_transfer_to_sender_protected() {
+    fn arbitraty_transfer_to_sender_protected(asset_id: AssetId) {
         let sender = storage.sender.read().unwrap();
-        let sender = match sender {
-            Identity::Address(sender) => sender,
-            _ => { revert(0)}
-        };
         require(storage.admin.read().is_some() && storage.admin.read().unwrap() == msg_sender().unwrap(), AccessError::CallerNotAdmin);
         // Report entry should not be created
-        transfer_to_address(sender, BASE_ASSET_ID, 1);
+        transfer(sender, asset_id, 1);
        
     }
 
-    fn transfer_to_msg_sender() {
+    fn transfer_to_msg_sender(asset_id: AssetId) {
         let sender = msg_sender().unwrap();
-        let sender = match sender {
-            Identity::Address(sender) => sender,
-            _ => { revert(0)}
-        };
         // Report entry should be created
-        // L134: The `Contract::transfer_to_msg_sender` function contains an arbitrary native asset transfer: `transfer_to_address(sender, BASE_ASSET_ID, 1)`
-        transfer_to_address(sender, BASE_ASSET_ID, 1);
+        // L134: The `Contract::transfer_to_msg_sender` function contains an arbitrary native asset transfer: `transfer_to_address(sender, DEFAULT_SUB_ID, 1)`
+        transfer(sender, asset_id, 1);
     }
 
-    fn transfer_to_msg_sender_msg_value() {
+    fn transfer_to_msg_sender_msg_value(asset_id: AssetId) {
         let sender = msg_sender().unwrap();
-        let sender = match sender {
-            Identity::Address(sender) => sender,
-            _ => { revert(0)}
-        };
+        
         // Report entry should be created
-        // L145: The `Contract::transfer_to_msg_sender_msg_value` function contains an arbitrary native asset transfer: `transfer_to_address(sender, BASE_ASSET_ID, msg_amount())`
-        transfer_to_address(sender, BASE_ASSET_ID, msg_amount());
+        // L145: The `Contract::transfer_to_msg_sender_msg_value` function contains an arbitrary native asset transfer: `transfer_to_address(sender, DEFAULT_SUB_ID, msg_amount())`
+        transfer(sender, asset_id, msg_amount());
     }
 
     fn arbitrary_asset_transfer(to_ident: Identity, to_address: Address, to_contract: ContractId, asset_id: AssetId, amount: u64, target: ContractId,
@@ -152,11 +138,7 @@ impl TestArbitraryAssetTransfer for Contract {
         single_value_type_arg: bool) {
         // Report entry should be created
         // L156: The `Contract::arbitrary_asset_transfer` function contains an arbitrary native asset transfer: `transfer(to_ident, asset_id, amount)`  
-        transfer(to_ident, asset_id, amount);
-        // L158: The `Contract::arbitrary_asset_transfer` function contains an arbitrary native asset transfer: `transfer_to_address(to_address, asset_id, amount)`
-        transfer_to_address(to_address, asset_id, amount);
-        // L160: The `Contract::arbitrary_asset_transfer` function contains an arbitrary native asset transfer: `force_transfer_to_contract(to_contract, asset_id, amount)`
-        force_transfer_to_contract(to_contract, asset_id, amount);
+        transfer(to_ident, asset_id, amount);  
         // L162: The `Contract::arbitrary_asset_transfer` function contains an arbitrary native asset transfer: `call_with_function_selector(target, function_selector, calldata, single_value_type_arg, call_params)`
         call_with_function_selector(target, function_selector, calldata, single_value_type_arg, call_params);
     }
@@ -172,24 +154,13 @@ impl TestArbitraryAssetTransfer for Contract {
         // Report entry should not be created
         transfer(to_ident, asset_id, amount);
         // Report entry should not be created
-        transfer_to_address(to_address, asset_id, amount);
-        // Report entry should not be created
-        force_transfer_to_contract(to_contract, asset_id, amount);
-        // Report entry should not be created
         call_with_function_selector(target, function_selector, calldata, single_value_type_arg, call_params);
         
     }    
      
     #[storage(read)]
-    fn arbitrary_asset_transfer_from_sender() {
+    fn arbitrary_asset_transfer_from_sender(asset_id: AssetId) {
         let sender = storage.sender.read().unwrap();
-        match sender {
-            Identity::Address => {
-                // Report entry should be created
-                // L191: The `Contract::arbitrary_asset_transfer_from_sender` function contains an arbitrary native asset transfer: `transfer(sender, BASE_ASSET_ID, 1)`
-                transfer(sender, BASE_ASSET_ID, 1);
-            },
-            _ => { revert(0)}
-        }
+        transfer(sender, asset_id, 1);
     }
 }

--- a/test/arbitrary_code_execution/src/main.sw
+++ b/test/arbitrary_code_execution/src/main.sw
@@ -20,38 +20,38 @@ storage {
 
 impl TestArbitraryCodeExecution for Contract {
     fn test_ldc_unrestricted() {
-        asm(r1: 0, r2: 0, r3: 0) {
+        asm(r1: 0, r2: 0, r3: 0, i0: 0) {
             // Report entry should be created:
             // L26: The `Contract::test_ldc_unrestricted` function uses the `LDC` instruction without access restriction: `ldc r1 r2 r3`. Consider checking against `msg_sender()` in order to limit access.
-            ldc r1 r2 r3;
-        };
+            ldc r1 r2 r3 i0;
+        }
     }
 
     #[storage(read)]
     fn test_ldc_restricted_1() {
         require(msg_sender().unwrap() == storage.owner.read(), "Only owner");
-        asm(r1: 0, r2: 0, r3: 0) {
+        asm(r1: 0, r2: 0, r3: 0, i0: 0) {
             // Report entry should not be created
-            ldc r1 r2 r3;
-        };
+            ldc r1 r2 r3 i0;
+        }
     }
 
     #[storage(read)]
     fn test_ldc_restricted_2() {
         require(imported_msg_sender().unwrap() == storage.owner.read(), "Only owner");
-        asm(r1: 0, r2: 0, r3: 0) {
+        asm(r1: 0, r2: 0, r3: 0, i0: 0) {
             // Report entry should not be created
-            ldc r1 r2 r3;
-        };
+            ldc r1 r2 r3 i0;
+        }
     }
 
     #[storage(read)]
     fn test_ldc_restricted_3() {
         require(std::auth::msg_sender().unwrap() == storage.owner.read(), "Only owner");
-        asm(r1: 0, r2: 0, r3: 0) {
+        asm(r1: 0, r2: 0, r3: 0, i0: 0) {
             // Report entry should not be created
-            ldc r1 r2 r3;
-        };
+            ldc r1 r2 r3 i0;
+        }
     }
 
     #[storage(read)]
@@ -59,10 +59,10 @@ impl TestArbitraryCodeExecution for Contract {
         if msg_sender().unwrap() != storage.owner.read() {
             revert(0);
         }
-        asm(r1: 0, r2: 0, r3: 0) {
+        asm(r1: 0, r2: 0, r3: 0, i0: 0) {
             // Report entry should not be created
-            ldc r1 r2 r3;
-        };
+            ldc r1 r2 r3 i0;
+        }
     }
 
     #[storage(read)]
@@ -70,10 +70,10 @@ impl TestArbitraryCodeExecution for Contract {
         if imported_msg_sender().unwrap() != storage.owner.read() {
             revert(0);
         }
-        asm(r1: 0, r2: 0, r3: 0) {
+        asm(r1: 0, r2: 0, r3: 0, i0: 0) {
             // Report entry should not be created
-            ldc r1 r2 r3;
-        };
+            ldc r1 r2 r3 i0;
+        }
     }
 
     #[storage(read)]
@@ -81,10 +81,10 @@ impl TestArbitraryCodeExecution for Contract {
         if std::auth::msg_sender().unwrap() != storage.owner.read() {
             revert(0);
         }
-        asm(r1: 0, r2: 0, r3: 0) {
+        asm(r1: 0, r2: 0, r3: 0, i0: 0) {
             // Report entry should not be created
-            ldc r1 r2 r3;
-        };
+            ldc r1 r2 r3 i0;
+        }
     }
 }
 

--- a/test/locked_native_asset/src/main.sw
+++ b/test/locked_native_asset/src/main.sw
@@ -1,5 +1,7 @@
 contract;
 
+use std::context::msg_amount;
+
 abi TestLockedNativeAsset {
     #[payable, storage(read, write)]
     fn deposit();
@@ -10,7 +12,7 @@ abi TestLockedNativeAsset {
 }
 
 storage {
-    balance: u64 = 0;
+    balance: u64 = 0,
 }
 
 impl TestLockedNativeAsset for Contract {
@@ -19,15 +21,19 @@ impl TestLockedNativeAsset for Contract {
     #[payable, storage(read, write)]
     fn deposit() {
         assert(msg_amount() > 0);
-        storage.balance = storage.balance + msg_amount();
+        let balance = storage.balance.try_read().unwrap_or(0);
+        let new_balance = balance + msg_amount();
+        storage.balance.write(new_balance);
     }
 
     // Report entry should be created
-    // L28: The `Contract::deposit2` function will lock native assets. Consider adding a withdraw function.   
+    // L30: The `Contract::deposit2` function will lock native assets. Consider adding a withdraw function.   
     #[payable, storage(read, write)]
     fn deposit2() {
         assert(msg_amount() > 0);
-        storage.balance = storage.balance + msg_amount();
+        let balance = storage.balance.try_read().unwrap_or(0);
+        let new_balance = balance + msg_amount();
+        storage.balance.write(new_balance);
     }
 
     fn withdraw() {

--- a/test/storage_field_mutability/src/main.sw
+++ b/test/storage_field_mutability/src/main.sw
@@ -1,5 +1,7 @@
 contract;
 
+use std::hash::Hash;
+
 abi TestStorageFieldMutability {
     #[storage(write)]
     fn initialize();

--- a/test/unchecked_call_payload/src/main.sw
+++ b/test/unchecked_call_payload/src/main.sw
@@ -22,7 +22,7 @@ impl TestUncheckedCallPayload for Contract {
     }
 
     fn test_unchecked_bytes_payload(payload: Bytes, call_params: CallParams) {
-        asm(r1: payload.buf.ptr, r2: call_params.coins, r3: call_params.asset_id, r4: call_params.gas) {
+        asm(r1: payload.ptr(), r2: call_params.coins, r3: call_params.asset_id, r4: call_params.gas) {
             // Report entry should be created:
             // L28: The `Contract::test_unchecked_bytes_payload` function uses the `payload: Bytes` parameter as the payload in a `CALL` instruction via register `r1` without checking its length, which may revert if the data is incorrect: `call r1 r2 r3 r4`
             call r1 r2 r3 r4;
@@ -31,7 +31,7 @@ impl TestUncheckedCallPayload for Contract {
     
     fn test_checked_bytes_payload_1(payload: Bytes, call_params: CallParams) {
         require(payload.len() >= 32, "Invalid payload");
-        asm(r1: payload.buf.ptr, r2: call_params.coins, r3: call_params.asset_id, r4: call_params.gas) {
+        asm(r1: payload.ptr(), r2: call_params.coins, r3: call_params.asset_id, r4: call_params.gas) {
             // Report entry should not be created
             call r1 r2 r3 r4;
         };
@@ -39,7 +39,7 @@ impl TestUncheckedCallPayload for Contract {
     
     fn test_checked_bytes_payload_2(payload: Bytes, call_params: CallParams) {
         require(32 <= payload.len(), "Invalid payload");
-        asm(r1: payload.buf.ptr, r2: call_params.coins, r3: call_params.asset_id, r4: call_params.gas) {
+        asm(r1: payload.ptr(), r2: call_params.coins, r3: call_params.asset_id, r4: call_params.gas) {
             // Report entry should not be created
             call r1 r2 r3 r4;
         };
@@ -49,7 +49,7 @@ impl TestUncheckedCallPayload for Contract {
         if payload.len() < 32 {
             revert(0);
         }
-        asm(r1: payload.buf.ptr, r2: call_params.coins, r3: call_params.asset_id, r4: call_params.gas) {
+        asm(r1: payload.ptr(), r2: call_params.coins, r3: call_params.asset_id, r4: call_params.gas) {
             // Report entry should not be created
             call r1 r2 r3 r4;
         };
@@ -59,7 +59,7 @@ impl TestUncheckedCallPayload for Contract {
         if 32 > payload.len() {
             revert(0);
         }
-        asm(r1: payload.buf.ptr, r2: call_params.coins, r3: call_params.asset_id, r4: call_params.gas) {
+        asm(r1: payload.ptr(), r2: call_params.coins, r3: call_params.asset_id, r4: call_params.gas) {
             // Report entry should not be created
             call r1 r2 r3 r4;
         };

--- a/test/unused_import/src/main.sw
+++ b/test/unused_import/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::constants::{BASE_ASSET_ID, ZERO_B256};
+use std::constants::{DEFAULT_SUB_ID, ZERO_B256};
 
 use std::logging::log;
 use std::asset::transfer;
@@ -18,7 +18,7 @@ use std::storage::storage_vec::*;
 
 configurable {
     ZERO_ADDRESS: b256 = ZERO_B256,
-    NATIVE_ASSET: AssetId = BASE_ASSET_ID,
+    NATIVE_ASSET: AssetId = DEFAULT_SUB_ID.into(),
 }
 
 trait HasValue {
@@ -30,12 +30,11 @@ impl HasValue for Contract {
 }
 
 abi TestUnusedImport {
-    fn test_redundant_import();
+    fn test_redundant_import(asset: AssetId);
 }
 
 impl TestUnusedImport for Contract {
-    fn test_redundant_import() {
-        let asset = BASE_ASSET_ID;
+    fn test_redundant_import(asset: AssetId) {
         let to = Identity::Address(Address::from(ZERO_B256));
         log(asset);
         log(to);


### PR DESCRIPTION
This fixes all the tests contracts that were broken with the latest changes.
It uses the new [sway-ast-stubs](https://github.com/ourovoros-io/sway-ast-stubs) version that is bumped to 0.63.1 of the sway libs.

It also unloads for the moment the scope until it is finalised.